### PR TITLE
Update packer configuration to use ubuntu 16.04 for ELK.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ packer_cache/*
 centos*
 ubuntu*
 *.qcow2
+ansible/roles/*

--- a/ansible/roles/.gitignore
+++ b/ansible/roles/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/base_openstack_es_k_ubuntu-16.04.json
+++ b/base_openstack_es_k_ubuntu-16.04.json
@@ -4,7 +4,7 @@
     "type": "openstack",
     "ssh_username": "ubuntu",
     "image_name": "ubuntu_pan_es_k_{{user `build_timestamp`}}",
-    "source_image": "d298ee89-e8e1-4c2b-b61e-dfda7b1f4335",
+    "source_image": "3eafe7dd-d90d-4d8e-ab70-e0c757a11bf7",
     "use_floating_ip": true,
     "floating_ip_pool": "ext-net",
     "security_groups": ["default", "remote SSH", "remote HTTP", "remote https"],
@@ -24,11 +24,10 @@
 	"ping -w 600 -c 2 -i 10 archive.ubuntu.com",
 	"ping -w 600 -c 2 -i 10 security.ubuntu.com",
 	"sudo apt-get update",
-	"sudo apt-get -y install git python python-dev python-setuptools software-properties-common libffi-dev",
-	"sudo git clone https://github.com/ansible/ansible.git /opt/ansible",
-	"cd /opt/ansible;sudo git submodule update --init --recursive",
-	"cd /opt/ansible;sudo python setup.py install",
-	"sudo apt-get -y upgrade"
+	"sudo apt-get -y install git python python-dev python-setuptools software-properties-common libffi-dev python-pip unattended-upgrades",
+	"sudo add-apt-repository ppa:ansible/ansible",
+	"sudo apt-get update",
+	"sudo apt-get -y install ansible"
       ]
     },
     {

--- a/base_openstack_es_ubuntu-16.04.json
+++ b/base_openstack_es_ubuntu-16.04.json
@@ -4,7 +4,7 @@
     "type": "openstack",
     "ssh_username": "ubuntu",
     "image_name": "ubuntu_pan_es_{{user `build_timestamp`}}",
-    "source_image": "d298ee89-e8e1-4c2b-b61e-dfda7b1f4335",
+    "source_image": "3eafe7dd-d90d-4d8e-ab70-e0c757a11bf7",
     "use_floating_ip": true,
     "floating_ip_pool": "ext-net",
     "security_groups": ["default", "remote SSH", "remote HTTP", "remote https"],
@@ -24,11 +24,10 @@
 	"ping -w 600 -c 2 -i 10 archive.ubuntu.com",
 	"ping -w 600 -c 2 -i 10 security.ubuntu.com",
 	"sudo apt-get update",
-	"sudo apt-get -y install git python python-dev python-setuptools software-properties-common libffi-dev",
-	"sudo git clone https://github.com/ansible/ansible.git /opt/ansible",
-	"cd /opt/ansible;sudo git submodule update --init --recursive",
-	"cd /opt/ansible;sudo python setup.py install",
-	"sudo apt-get -y upgrade"
+	"sudo apt-get -y install git python python-dev python-setuptools software-properties-common libffi-dev python-pip unattended-upgrades",
+	"sudo add-apt-repository ppa:ansible/ansible",
+	"sudo apt-get update",
+	"sudo apt-get -y install ansible"
       ]
     },
     {
@@ -37,7 +36,6 @@
       "group_vars": "./ansible/group_vars",
       "role_paths": [
 	"./ansible/roles/jmatt.elasticsearch-packages",
-	"./ansible/roles/jmatt.kibana-packages",
 	"./ansible/roles/jmatt.java-packages"
       ]
     },

--- a/base_openstack_lfr_ubuntu-16.04.json
+++ b/base_openstack_lfr_ubuntu-16.04.json
@@ -4,7 +4,7 @@
     "type": "openstack",
     "ssh_username": "ubuntu",
     "image_name": "ubuntu_pan_lfr_{{user `build_timestamp`}}",
-    "source_image": "d298ee89-e8e1-4c2b-b61e-dfda7b1f4335",
+    "source_image": "3eafe7dd-d90d-4d8e-ab70-e0c757a11bf7",
     "use_floating_ip": true,
     "floating_ip_pool": "ext-net",
     "security_groups": ["default", "remote SSH", "remote HTTP", "remote https", "elasticsearch"],
@@ -24,11 +24,10 @@
 	"ping -w 600 -c 2 -i 10 archive.ubuntu.com",
 	"ping -w 600 -c 2 -i 10 security.ubuntu.com",
 	"sudo apt-get update",
-	"sudo apt-get -y install git python python-dev python-setuptools software-properties-common libffi-dev",
-	"sudo git clone https://github.com/ansible/ansible.git /opt/ansible",
-	"cd /opt/ansible;sudo git submodule update --init --recursive",
-	"cd /opt/ansible;sudo python setup.py install",
-	"sudo apt-get -y upgrade"
+	"sudo apt-get -y install git python python-dev python-setuptools software-properties-common libffi-dev python-pip unattended-upgrades",
+	"sudo add-apt-repository ppa:ansible/ansible",
+	"sudo apt-get update",
+	"sudo apt-get -y install ansible"
       ]
     },
     {


### PR DESCRIPTION
  * Use new Ubuntu 16.04 base image.
  * Use system ansible now that 2.1+ is stable and released.
  * Wait for Nebula's internal networking and DNS to resolve
    before running updates.

	modified:   .gitignore
	deleted:    ansible/roles/.gitignore
	modified:   base_openstack_es_k_ubuntu-16.04.json
	modified:   base_openstack_es_ubuntu-16.04.json
	modified:   base_openstack_lfr_ubuntu-16.04.json