### PR TITLE
[DM-5737] Add a base openstack development Ubuntu 16.04 image to use with Vagrant.

### DIFF
--- a/ansible/main-base.yml
+++ b/ansible/main-base.yml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+
+  vars_files:
+    - "group_vars/all"
+
+  roles:
+    - jmatt.java-packages
+    - jmatt.editor-packages

--- a/base_openstack_ubuntu-16.04.json
+++ b/base_openstack_ubuntu-16.04.json
@@ -1,0 +1,54 @@
+{
+  "builders": [{
+    "name": "openstack_ubuntu_16.04_base",
+    "type": "openstack",
+    "ssh_username": "ubuntu",
+    "image_name": "ubuntu_base_{{user `build_timestamp`}}",
+    "source_image": "3eafe7dd-d90d-4d8e-ab70-e0c757a11bf7",
+    "use_floating_ip": true,
+    "floating_ip_pool": "ext-net",
+    "security_groups": ["default", "remote SSH", "remote HTTP", "remote https"],
+    "networks": ["5b8760e4-06ed-4f73-8c8d-bb1543b0bc74"],
+    "flavor": "m1.small",
+    "ssh_keypair_name": "jmatt_lsst",
+    "ssh_private_key_file": "/Users/jmatt/.ssh/id_rsa_lsst",
+    "ssh_timeout": "30m"
+  }],
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "echo 'ubuntu' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "inline": [
+	"ping -w 600 -c 2 -i 10 141.142.2.2",
+	"ping -w 600 -c 2 -i 10 8.8.8.8",
+	"ping -w 600 -c 2 -i 10 archive.ubuntu.com",
+	"ping -w 600 -c 2 -i 10 security.ubuntu.com",
+	"sudo apt-get update",
+	"sudo apt-get -y install git python python-dev python-setuptools software-properties-common libffi-dev python-pip unattended-upgrades",
+	"sudo add-apt-repository ppa:ansible/ansible",
+	"sudo apt-get update",
+	"sudo apt-get -y install ansible"
+      ]
+    },
+    {
+      "type": "ansible-local",
+      "playbook_file": "./ansible/main-base.yml",
+      "group_vars": "./ansible/group_vars",
+      "role_paths": [
+	"./ansible/roles/jmatt.editor-packages",
+	"./ansible/roles/jmatt.java-packages"
+      ]
+    },
+    {
+      "type": "shell",
+      "execute_command": "echo 'ubuntu' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "scripts": [
+	"scripts/sshd.sh",
+	"scripts/cleanup.sh"
+      ]
+    }
+  ],
+  "variables": {
+    "build_timestamp": "{{isotime \"20060102150405\"}}"
+  }
+},


### PR DESCRIPTION
Add a base openstack development Ubuntu 16.04 image to use with Vagrant.

git-lfs needs a development and test server, so this is to enable that case.

	new file:   ansible/main-base.yml
	new file:   base_openstack_ubuntu-16.04.json